### PR TITLE
Corrige nome da variável de `date` para `data`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -8,7 +8,7 @@ export interface RegionalHoliday {
 }
 
 export interface Holidays {
-    date: string;
+    data: string;
     nacionais: NationalHoliday[];
     regionais: RegionalHoliday[];
 }


### PR DESCRIPTION
fix Holidays.date to Holidays.data

Conforme @rmrantunes mencionou no Pull Request anterior: https://github.com/paulohenriquesn/eferiado/pull/12#issuecomment-816907108